### PR TITLE
sovle the prepare_data error

### DIFF
--- a/data/data_pipe.py
+++ b/data/data_pipe.py
@@ -88,7 +88,8 @@ def load_mx_rec(rec_path):
     for idx in tqdm(range(1,max_idx)):
         img_info = imgrec.read_idx(idx)
         header, img = mx.recordio.unpack_img(img_info)
-        label = int(header.label)
+        # label = int(header.label)
+        label = int(header.label[0])
         img = Image.fromarray(img)
         label_path = save_path/str(label)
         if not label_path.exists():


### PR DESCRIPTION
when convert bin datasets to folders, it will report:
```
Traceback (most recent call last):
  File "prepare_data.py", line 12, in <module>
    load_mx_rec(rec_path)
  File "/home/user1/InsightFace_Pytorch/data/data_pipe.py", line 92, in load_mx_rec
    label = int(header.label)
TypeError: only size-1 arrays can be converted to Python scalars
```